### PR TITLE
Extract first name and last names for the congresistas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ data/bill_jsons/*.json
 data/ocr_cache/*.txt
 *.db
 *.csv
+*.ipynb
 
 # DS_Store
 .DS_Store

--- a/estecon/backend/database/models.py
+++ b/estecon/backend/database/models.py
@@ -220,7 +220,9 @@ class Congresista(Base):
 
     Attributes:
         id (str): Unique identifier for the person.
-        nombre (str): Name of the person.
+        full_name (str): Full name of the person (first_name + last_name)
+        first_name (str): First and Middle name of the person
+        last_name (str): Last names of the person
         leg_period (str): Legislative period.
         party_id (str): Unique identifier for the party.
         votes_in_election (int): Number of votes obtain in elections
@@ -231,7 +233,9 @@ class Congresista(Base):
     __tablename__ = 'congresistas'
 
     id = Column(Integer, nullable=False)
-    nombre = Column(String, nullable=False)
+    full_name = Column(String, nullable=False)
+    first_name = Column(String, nullable=False)
+    last_name = Column(String, nullable=False)
     leg_period = Column(Enum(LegPeriod, name = "leg_period"), nullable=False)
     party_id = Column(Integer, ForeignKey('partidos.party_id'), nullable=False)
     votes_in_election = Column(Integer, nullable=False)

--- a/estecon/backend/scrapers/schema.py
+++ b/estecon/backend/scrapers/schema.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_validator, ConfigDict
+from pydantic import BaseModel, field_validator, ConfigDict, model_validator
 from estecon.backend import (VoteOption, AttendanceStatus, BillStepType, RoleTypeBill,
                      LegPeriod, Legislature, LegislativeYear, Proponents,
                      TypeOrganization, RoleOrganization)
@@ -241,7 +241,9 @@ class Congresista(PrintableModel):
 
     Attributes:
         id (str): Unique identifier for the person.
-        nombre (str): Name of the person.
+        full_name (str): Full name of the person (first_name + last_name)
+        first_name (str): First and Middle name of the person
+        last_name (str): Last names of the person
         leg_period (str): Legislative period.
         party_id (str): Unique identifier for the party.
         votes_in_election (int): Number of votes obtain in elections
@@ -252,7 +254,9 @@ class Congresista(PrintableModel):
     # Attributes that fit in Popolo structure
     id: int
     leg_period: LegPeriod
-    nombre: str
+    full_name: str
+    first_name: str
+    last_name: str
     party_id: int
     votes_in_election: int
     dist_electoral: Optional[str]
@@ -261,6 +265,16 @@ class Congresista(PrintableModel):
 
     model_config = ConfigDict(use_enum_values=False)
 
+    @model_validator(mode='after')
+    def check_full_name(cls, model):
+        expected = f"{model.first_name.strip()} {model.last_name.strip()}".strip()
+        if model.full_name.strip() != expected:
+            raise ValueError(
+                f'`full_name` ("{model.full_name}") does not match '
+                f'`first_name` + " " + `last_name` ("{expected}")'
+            )
+        return model
+    
     def __str__(self):
         return '\n'.join(f"{key}: {value}" for key, value in self.model_dump().items()) 
 

--- a/estecon/tests/test_models.py
+++ b/estecon/tests/test_models.py
@@ -36,7 +36,9 @@ def test_create_congresista(session):
     congresista = Congresista(
         id=1,
         leg_period=LegPeriod.PERIODO_2021_2026,
-        nombre="Ana Torres",
+        full_name="Ana María Torres Lara",
+        first_name="Ana María",
+        last_name="Torres Lara",
         party_id=100,
         votes_in_election=25000,
         dist_electoral="Lima",
@@ -45,7 +47,9 @@ def test_create_congresista(session):
     )
     session.add(congresista)
     session.commit()
-    assert congresista.nombre == "Ana Torres"
+    assert congresista.full_name == "Ana María Torres Lara"
+    assert congresista.first_name == "Ana María"
+    assert congresista.last_name == "Torres Lara"
 
 def test_create_bill(session):
     bill = Bill(

--- a/estecon/tests/test_schema.py
+++ b/estecon/tests/test_schema.py
@@ -101,14 +101,18 @@ def test_congresista_creation():
     congresista = Congresista(
         id=1,
         leg_period=LegPeriod.PERIODO_2021_2026,
-        nombre="Juan Pérez",
+        full_name="Juan Jose Pérez Torres",
+        first_name="Juan Jose",
+        last_name="Pérez Torres",
         party_id=5,
         votes_in_election=25000,
         dist_electoral="Lima",
         condicion="Activo",
         website="http://congreso.gob.pe/juanperez"
     )
-    assert congresista.nombre == "Juan Pérez"
+    assert congresista.full_name == "Juan Jose Pérez Torres"
+    assert congresista.first_name == "Juan Jose"
+    assert congresista.last_name == "Pérez Torres"
 
 def test_organization_creation():
     org = Organization(


### PR DESCRIPTION
## 1. What does this PR do?

This pull request creates the `split_names` utility to correctly handle the variety of Peruvian full-name formats encountered in our scraping pipeline. It adds explicit rules for names with 3–5 tokens, multi-word particles (`de`, `del`, `de la`, `de los`), and arbitrarily long names, ensuring all existing test cases pass.

## 2. How was the functionality tested and verified?
This is a checklist to make sure that the pull request includes complete functionality.

### Code quality
- [x] All new and existing tests pass locally.
- [x] My code added tests using pytest for any new functionality.
- [x] My PR includes documentation updates as relevant (new external commands, updates to options, changes to names, etc.)

### Code review
- [ ] If the changes would break previous functionality, I've communicated this in (1)
- [ ] If there's anything that the reviewer should know, I've added that as a note on the issue or this pull request.
